### PR TITLE
Fix security flag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ git clone https://github.com/Engelnicolas/NOAH.git
 cd NOAH
 
 # Deploy core services (uses root security context for compatibility)
-./Script/noah-infra deploy -m root
+./Script/noah-infra deploy --security root
 
 # Check deployment status
 kubectl get pods -n noah


### PR DESCRIPTION
## Summary
- fix security option flag in README
- confirm user guide already uses `--security root`

## Testing
- `pre-commit run --files README.md docs/USER_GUIDE.md` *(fails: InvalidConfigError)*

------
https://chatgpt.com/codex/tasks/task_e_6876478de0e88326a00bd7120d22e9d7