### PR TITLE
Fix CI paths and validation script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
           VALIDATE_MARKDOWN: true
           VALIDATE_ANSIBLE: true
           # Use custom configs
-          YAML_CONFIG_FILE: .yamllint.yml
-          MARKDOWN_CONFIG_FILE: .markdownlint.yml
+          YAML_CONFIG_FILE: .github/linters/.yamllint.yml
+          MARKDOWN_CONFIG_FILE: .github/linters/.markdownlint.yml
           # Disable strict mode
           SUPPRESS_POSSUM: true
           DISABLE_ERRORS: false

--- a/Script/noah-validate
+++ b/Script/noah-validate
@@ -34,17 +34,17 @@ warnings=0
 # Logging functions
 log_success() {
     echo -e "${GREEN}✅ $1${NC}"
-    ((success++))
+    success=$((success + 1))
 }
 
 log_error() {
     echo -e "${RED}❌ $1${NC}"
-    ((errors++))
+    errors=$((errors + 1))
 }
 
 log_warning() {
     echo -e "${YELLOW}⚠️  $1${NC}"
-    ((warnings++))
+    warnings=$((warnings + 1))
 }
 
 log_info() {


### PR DESCRIPTION
## Summary
- use custom linter paths from `.github/linters`
- avoid `set -e` exit in `noah-validate` logging counters

## Testing
- `bash Test/unified_tests.sh --deps-only`
- `./Script/noah-validate`

------
https://chatgpt.com/codex/tasks/task_e_687652b8424083269994c5828bd43212